### PR TITLE
fix: #65 导入文件渲染画布时, 选中元素的矩形框层级问题修复

### DIFF
--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -405,6 +405,7 @@ export class App extends BaseService<EventArgs> {
     const layer = Konva.Node.create(json, 'layer');
     this.mainLayer = layer;
     this.stage.add(this.mainLayer);
+    this.resetPluginsLayer([...this.installedPlugins.keys()]);
     this.render();
     return this;
   }
@@ -453,6 +454,15 @@ export class App extends BaseService<EventArgs> {
     }
     const aboutToChangePlugins = this.getPlugins(plugins);
     aboutToChangePlugins?.forEach((plugin) => plugin?.destroy());
+    return this;
+  }
+
+  public resetPluginsLayer(plugins: string | string[]): this {
+    if (!Array.isArray(plugins)) {
+      plugins = [plugins];
+    }
+    const aboutToChangePlugins = this.getPlugins(plugins);
+    aboutToChangePlugins?.forEach((plugin) => plugin?.resetLayer?.());
     return this;
   }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -38,6 +38,7 @@ export interface Plugin {
   enable?(): void;
   disable?(): void;
   isEnabled?(): boolean;
+  resetLayer?(): void;
 }
 
 export interface ToolEvent {

--- a/packages/plugin-selector/src/index.ts
+++ b/packages/plugin-selector/src/index.ts
@@ -79,6 +79,10 @@ export class SelectorPlugin implements Plugin {
   private onCanvasCleared = (): void => {
     this.selector?.cancelSelect();
   };
+
+  public resetLayer() {
+    this.selector?.resetLayer();
+  }
 }
 
 export default SelectorPlugin;

--- a/packages/plugin-selector/src/selector.ts
+++ b/packages/plugin-selector/src/selector.ts
@@ -383,6 +383,12 @@ export class Selector {
     }
   };
 
+  public resetLayer(): void {
+    this.optionLayer.remove();
+    this.app.stage.add(this.optionLayer);
+    this.app.render();
+  }
+
   public destroy(): void {
     this.transformer.off('transformstart', this.onTransformStart);
     this.transformer.off('transformend', this.onTransformEnd);


### PR DESCRIPTION
在 Selector 插件中添加 `resetLayer` 方法， app.fromJSON 方法中执行插件的 `resetLayer` 方法。