### PR TITLE
fix #98 disable stage listening when transformer under drag

### DIFF
--- a/packages/plugin-selector/src/selector.ts
+++ b/packages/plugin-selector/src/selector.ts
@@ -324,11 +324,17 @@ export class Selector {
   };
 
   private onDragStart = (): void => {
+    this.app.stage.listening(false);
+
     this.app.emit('node:transform:start', { nodes: [...this.selected.values()] });
     this.app.emit('node:update:before', { nodes: [...this.selected.values()] });
   };
 
   private onDragEnd = (): void => {
+    setTimeout(() => {
+      this.app.stage.listening(true);
+    }, 100);
+
     this.app.emit('node:transform:end', { nodes: [...this.selected.values()] });
     this.app.emit('node:updated', { nodes: [...this.selected.values()] });
   };


### PR DESCRIPTION
After `transformer` fires event of `dragend`, it would spread event like `mousedown` to each nodes, which then collected by `Stage`, this would make tool of `arrow` execute it handler multiple times, and raise #98 